### PR TITLE
Add lifecycle signals to Quest resource

### DIFF
--- a/addons/quest_system/quest_resource.gd
+++ b/addons/quest_system/quest_resource.gd
@@ -7,6 +7,10 @@ class_name Quest
 @export_multiline var quest_description: String
 @export_multiline var quest_objective: String
 
+signal started
+signal updated
+signal completed
+
 var objective_completed: bool = false:
 	set(value):
 		objective_completed = value
@@ -14,10 +18,10 @@ var objective_completed: bool = false:
 		return objective_completed
 
 func update() -> void:
-	objective_completed = true
+	updated.emit()
 
 func start() -> void:
-	pass
+	started.emit()
 
 func complete() -> void:
-	pass
+	completed.emit()

--- a/docs/api/quest_resource.md
+++ b/docs/api/quest_resource.md
@@ -32,11 +32,23 @@ To make a custom quest make a script that inherits `Quest` and implement your ow
 | [**complete**](#void-complete)**()** | **void** |
 | [**update**](#void-update)**()** | **void** |
 
---------------
-
 #### _void_ **start()**
 > Gets called after [start_quest](#quest-start_questquest-quest) 
 #### _void_ **complete()**
 > Gets called after [complete_quest](#quest-complete_questquest-quest) only if `objective_completed` is set to `true`
 #### _void_ **update()**
 > Abstract method to update the quest progress. It is suggested to set `objective_completed` to `true` here.
+
+--------------
+
+### Signals
+
+| signal | description |
+| ------ | ----------- |
+| started() | Emitted when the `start()` method is invoked |
+| updated() | Emitted when the `update()` method is invoked |
+| completed() | Emitted when the `complete()` method is invoked |
+
+In order to have these called in your own resources that extend `Quest`, remember to call `super.update()` in your `update` implementation, `super.start()` in your `start` implementation and `super.complete()` in your `complete` implementation.
+
+You can also call `emit()` on `started`, `updated` and `completed` signals from your implementation in any of the functions that would require that (for instance if your UI relies on these signals to update itself).


### PR DESCRIPTION
## Summary

Implement #11 

I removed `objective_completed = true` from the default `update()` implementation to make it useable in a `super.update()` call.

## Checklist

<!-- Put an x inside [ ] to check the box -->

- [x] This PR changes something in the code (e.g. for better performance).
    - [x] If any code changes had taken place, I've tested them before committing.
- [x] This PR adds something new.
- [ ] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)