### PR TITLE
Added a new singal for when a quest objective_completed bool has been changed.

### DIFF
--- a/addons/quest_system/quest_resource.gd
+++ b/addons/quest_system/quest_resource.gd
@@ -21,6 +21,8 @@ signal started
 signal updated
 ## Emitted by default when [method complete] gets called.
 signal completed
+## Emitted by default when [objective_completed] gets set.
+signal objective_status_updated(value: bool)
 
 ## Whether the objective is fulfilled or not.[br]
 ## Must be set to true to be able to complete the quest;[br]
@@ -28,6 +30,7 @@ signal completed
 var objective_completed: bool = false:
 	set(value):
 		objective_completed = value
+        objective_status_updated.emit(value)
 	get:
 		return objective_completed
 

--- a/addons/quest_system/quest_resource.gd
+++ b/addons/quest_system/quest_resource.gd
@@ -30,7 +30,7 @@ signal objective_status_updated(value: bool)
 var objective_completed: bool = false:
 	set(value):
 		objective_completed = value
-        objective_status_updated.emit(value)
+		objective_status_updated.emit(value)
 	get:
 		return objective_completed
 

--- a/docs/api/quest_resource.md
+++ b/docs/api/quest_resource.md
@@ -16,11 +16,12 @@ To make a custom quest make a script that inherits `Quest` and implement your ow
 
 | Name           | Type        | Description |
 | ---------------| ------------| ------------|
-| `id`           | [int](https://docs.godotengine.org/en/stable/classes/class_int.html) | Unique Identifier for a quest |
-| `quest_name`   | [String](https://docs.godotengine.org/en/stable/classes/class_string.html) | The name of a quest |
-| `quest_description` | [String](https://docs.godotengine.org/en/stable/classes/class_string.html) | Description of the quest |
-| `quest_objective` | [String](https://docs.godotengine.org/en/stable/classes/class_string.html) | Description of the objective of the quest |
-| `objective_completed` **_= false_** | [bool](https://docs.godotengine.org/en/stable/classes/class_bool.html) | Tracks the progress of the quest.<br>If it's false, the quest can't be moved to the CompletedPool |
+| `id`           | [int](https://docs.godotengine.org/en/stable/classes/class_int.html) | Unique Identifier for a quest. |
+| `quest_name`   | [String](https://docs.godotengine.org/en/stable/classes/class_string.html) | The name of a quest. |
+| `quest_description` | [String](https://docs.godotengine.org/en/stable/classes/class_string.html) | Description of the quest. |
+| `quest_objective` | [String](https://docs.godotengine.org/en/stable/classes/class_string.html) | Description of the objective of the quest. |
+| `objective_completed` **_= false_** | [bool](https://docs.godotengine.org/en/stable/classes/class_bool.html) | Tracks the progress of the quest.<br>If it's false, the quest can't be moved to the CompletedPool.
+<br>When set, it will emit the objective_status_updated(value: bool) signal to indicate a change in the objective completion state. |
 
 ### Methods
 
@@ -54,6 +55,7 @@ To make a custom quest make a script that inherits `Quest` and implement your ow
 | started() | Emitted when the `start()` method is invoked |
 | updated() | Emitted when the `update()` method is invoked |
 | completed() | Emitted when the `complete()` method is invoked |
+| objective_status_updated(value: bool) | Emitted when the `objective_completed` bool value is set |
 
 In order to have these called in your own resources that extend `Quest`, remember to call `super.update()` in your `update` implementation, `super.start()` in your `start` implementation and `super.complete()` in your `complete` implementation.
 


### PR DESCRIPTION
## Summary
Added a new singal `objective_status_updated(value: bool)` in `quest_resource.gd`.
This signal is emitted whenever the `objective_completed` bool value is set

Closes #26 

## Checklist
- [x] This PR changes something in the code (e.g. for better performance).
    - [x] If any code changes had taken place, I've tested them before committing.
    - [x] I've properly updated the documentation (under /docs) to reflect the changes I've made.
- [x] This PR adds something new.
    - [ ] I've properly wrote tests that reflect the changes I've made.
- [x] This PR "fixes" an issue #26 
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)